### PR TITLE
GTK4 and Gnome Shell 40 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,11 +3,7 @@
   "description": "Hide battery icon in top panel, if battery is fully charged and AC is connected",
   "url": "https://github.com/ai/autohide-battery",
   "uuid": "autohide-battery@sitnik.ru",
-  "shell-version": [
-    "3.34",
-    "3.36",
-    "40"
-  ],
+  "shell-version": ["40"],
   "gettext-domain": "autohide-battery",
-  "version": 17
+  "version": 18
 }

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "uuid": "autohide-battery@sitnik.ru",
   "shell-version": [
     "3.34",
-    "3.36"
+    "3.36",
+    "40"
   ],
   "gettext-domain": "autohide-battery",
   "version": 17

--- a/prefs.js
+++ b/prefs.js
@@ -12,7 +12,10 @@ function buildPrefsWidget () {
   let settings = ExtensionUtils.getSettings('ru.sitnik.autohide-battery')
 
   let grid = new Gtk.Grid({
-    margin: 24,
+    margin_top: 24,
+    margin_bottom: 24,
+    margin_start: 24,
+    margin_end: 24,
     column_spacing: 24,
     row_spacing: 12,
     halign: Gtk.Align.CENTER
@@ -44,7 +47,5 @@ function buildPrefsWidget () {
   settings.connect('changed::hide-on', () => {
     field.set_value(settings.get_int('hide-on'))
   })
-
-  grid.show_all()
   return grid
 }


### PR DESCRIPTION
I think don't need more changes for the extension to work correctly in version 40 of Gnome-Shell; 

### prefs.js
show_all() no longer supported in GTK4.
margin no longer supported in GTK4.

### metadata.json
added "40.0" to the shell version.