### PR TITLE
Add setting to keep the extension active on the lock screen

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,7 +2,7 @@ const ExtensionUtils = imports.misc.extensionUtils
 const UPower = imports.ui.status.power.UPower
 const Main = imports.ui.main
 
-let batteryWatching, settingsWatching, settings
+let batteryWatching, settingsWatching, settings, disabled
 
 function show() {
   getBattery((proxy, icon) => {
@@ -41,18 +41,24 @@ function getBattery(callback) {
 }
 
 function enable() {
-  settings = ExtensionUtils.getSettings('ru.sitnik.autohide-battery')
-  settingsWatching = settings.connect('changed::hide-on', update)
-  getBattery(proxy => {
-    batteryWatching = proxy.connect('g-properties-changed', update)
-  })
-  update()
+  if (disabled) {
+    disabled = false;
+    settings = ExtensionUtils.getSettings('ru.sitnik.autohide-battery')
+    settingsWatching = settings.connect('changed::hide-on', update)
+    getBattery(proxy => {
+      batteryWatching = proxy.connect('g-properties-changed', update)
+    })
+    update()
+  }
 }
 
 function disable() {
-  if (settings) settings.disconnect(settingsWatching)
-  getBattery(proxy => {
-    proxy.disconnect(batteryWatching)
-  })
-  show()
+  if(Main.sessionMode.currentMode != 'unlock-dialog' || !settings.get_boolean('active-on-lockscreen')) {
+    disabled = true;
+    if (settings) settings.disconnect(settingsWatching)
+    getBattery(proxy => {
+      proxy.disconnect(batteryWatching)
+    })
+    show()
+  }
 }

--- a/po/autohide-battery.pot
+++ b/po/autohide-battery.pot
@@ -24,3 +24,7 @@ msgstr ""
 #: prefs.js:33
 msgid "If you changed maximum charging level to extend battery life"
 msgstr ""
+
+#: prefs.js:44
+msgid "Keep extension active on lockscreen"
+msgstr ""

--- a/schemas/ru.sitnik.autohide-battery.gschema.xml
+++ b/schemas/ru.sitnik.autohide-battery.gschema.xml
@@ -5,5 +5,9 @@
       <summary>Minimum battery level to hide icon</summary>
       <default>100</default>
     </key>
+    <key name="active-on-lockscreen" type="b">
+      <summary>Is the extension active on lockscreen</summary>
+      <default>false</default>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Currently, the battery icon still appear on the lock screen, where the extension is disabled. This commit adds a setting to make the extension work even on the lock screen, while still correctly showing the icon again when the extension is disabled by the user.