### PR TITLE
Fix possible race in UPower import

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,5 @@
 const ExtensionUtils = imports.misc.extensionUtils
-const UPower = imports.ui.status.power.UPower
+const Power = imports.ui.status.power
 const Main = imports.ui.main
 
 let batteryWatching, settingsWatching, settings, disabled
@@ -19,9 +19,9 @@ function hide() {
 function update() {
   let hideOn = settings.get_int('hide-on')
   getBattery(proxy => {
-    let isDischarging = proxy.State === UPower.DeviceState.DISCHARGING
-    let isFullyCharged = proxy.State === UPower.DeviceState.FULLY_CHARGED
-    if (proxy.Type !== UPower.DeviceKind.BATTERY) {
+    let isDischarging = proxy.State === Power.UPower.DeviceState.DISCHARGING
+    let isFullyCharged = proxy.State === Power.UPower.DeviceState.FULLY_CHARGED
+    if (proxy.Type !== Power.UPower.DeviceKind.BATTERY) {
       show()
     } else if (isFullyCharged) {
       hide()


### PR DESCRIPTION
On my system (GNOME 42, gjs 1.72.0) `power.UPower` is undefined when it
is imported directly.  However if you only import `power` and later
access `UPower` in `update()` then it seems to be defined.