### PR TITLE
import UPower directly from GI

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,6 @@
 const ExtensionUtils = imports.misc.extensionUtils
-const Power = imports.ui.status.power
 const Main = imports.ui.main
+const UPower = imports.gi.UPowerGlib
 
 let batteryWatching, settingsWatching, settings, disabled
 
@@ -19,10 +19,9 @@ function hide() {
 function update() {
   let hideOn = settings.get_int('hide-on')
   getBattery(proxy => {
-    if (!Power.UPower) return
-    let isDischarging = proxy.State === Power.UPower.DeviceState.DISCHARGING
-    let isFullyCharged = proxy.State === Power.UPower.DeviceState.FULLY_CHARGED
-    if (proxy.Type !== Power.UPower.DeviceKind.BATTERY) {
+    let isDischarging = proxy.State === UPower.DeviceState.DISCHARGING
+    let isFullyCharged = proxy.State === UPower.DeviceState.FULLY_CHARGED
+    if (proxy.Type !== UPower.DeviceKind.BATTERY) {
       show()
     } else if (isFullyCharged) {
       hide()


### PR DESCRIPTION
Hey, upon inspecting gnome-shell (42.0 and 41.4) I found that `ui.state.power.UPower` is just an import of `gi.UPowerGlib` and importing that directly seems to work without the undefined even in the initial `update()`.  This might be preferable over the `if (!power.UPower)` check.

![image](https://user-images.githubusercontent.com/428540/160161796-e7dd88ec-a05d-438e-89b3-11b1357bb366.png)


