### PR TITLE
Add quick settings support (Gnome 43)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,9 +34,17 @@ function update() {
 }
 
 function getBattery(callback) {
-  let menu = Main.panel.statusArea.aggregateMenu
-  if (menu && menu._power) {
-    callback(menu._power._proxy, menu._power)
+  if (Main.panel.statusArea.quickSettings) {
+    let system = Main.panel.statusArea.quickSettings._system
+    if (system._systemItem._powerToggle) {
+      callback(system._systemItem._powerToggle._proxy, system)
+    }
+  }
+  else {
+    let menu = Main.panel.statusArea.aggregateMenu
+    if (menu && menu._power) {
+      callback(menu._power._proxy, menu._power)
+    }
   }
 }
 


### PR DESCRIPTION
The aggregate menu was removed in Gnome 43 and replaced with the quick settings menu. This checks for the quick settings menu and uses the aggregate menu as a fallback.